### PR TITLE
Email confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,20 +54,18 @@ mutation ResetPassword(
 
 ### Mutation `confirmCustomerEmail`
 
-> ⚠️ This is not tested but implemented !!! ⚠️
-
 Here is an example use of it:
 
 ```graphql
 mutation ConfirmCustomerEmail(
     $password: String!
     $key: String!
-    $id: String!
+    $email: String!
 ) {
     confirmCustomerEmail(
         password: $password
         key: $key
-        id: $id
+        email: $email
     ) {
         status
         token
@@ -99,7 +97,7 @@ The variables for input above might look like:
 ```json
 {
     "key": "0129309912",
-    "id": "0000000000",
+    "email": "alfreds+valid12@gmail.com",
     "password": "Testing123_"
 }
 ```

--- a/src/Model/Customer/ExtractCustomerData.php
+++ b/src/Model/Customer/ExtractCustomerData.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/module-customer-graph-ql
+ * @link https://github.com/scandipwa/module-customer-graph-ql
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\CustomerGraphQl\Model\Customer;
+
+use Magento\Customer\Api\Data\CustomerInterface;
+
+/**
+ * Transform single customer data from object to in array format
+ */
+class ExtractCustomerData extends \Magento\CustomerGraphQl\Model\Customer\ExtractCustomerData
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(CustomerInterface $customer): array
+    {
+        $confirmationRequired = $customer->getConfirmation() ?: false;
+        $customerData = parent::execute($customer);
+        $customerData['confirmation_required'] = $confirmationRequired;
+        return $customerData;
+    }
+}

--- a/src/Model/Customer/GetCustomer.php
+++ b/src/Model/Customer/GetCustomer.php
@@ -88,12 +88,6 @@ class GetCustomer extends \Magento\CustomerGraphQl\Model\Customer\GetCustomer
             throw new GraphQlAuthenticationException(__('The account is locked.'));
         }
 
-        try {
-            $confirmationStatus = $this->accountManagement->getConfirmationStatus($currentUserId);
-        } catch (LocalizedException $e) {
-            throw new GraphQlInputException(__($e->getMessage()));
-        }
-
         return $customer;
     }
 

--- a/src/Model/Customer/GetCustomer.php
+++ b/src/Model/Customer/GetCustomer.php
@@ -24,7 +24,7 @@ use Magento\Framework\GraphQl\Exception\GraphQlAuthenticationException;
 use Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
-use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
+use Magento\GraphQl\Model\Query\ContextInterface;
 
 /**
  * Get customer

--- a/src/Model/Customer/GetCustomer.php
+++ b/src/Model/Customer/GetCustomer.php
@@ -69,7 +69,7 @@ class GetCustomer extends \Magento\CustomerGraphQl\Model\Customer\GetCustomer
         $currentUserId = $context->getUserId();
         $currentUserType = $context->getUserType();
 
-        if (true === $this->isUserGuest($currentUserId, $currentUserType)) {
+        if ($this->isUserGuest($currentUserId, $currentUserType) === true) {
             throw new GraphQlAuthorizationException(__('The current customer isn\'t authorized.'));
         }
 

--- a/src/Model/Customer/GetCustomer.php
+++ b/src/Model/Customer/GetCustomer.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/module-customer-graph-ql
+ * @link https://github.com/scandipwa/module-customer-graph-ql
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\CustomerGraphQl\Model\Customer;
+
+use Magento\Authorization\Model\UserContextInterface;
+use Magento\Customer\Api\AccountManagementInterface;
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Customer\Model\AuthenticationInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\GraphQl\Exception\GraphQlAuthenticationException;
+use Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
+use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
+
+/**
+ * Get customer
+ */
+class GetCustomer extends \Magento\CustomerGraphQl\Model\Customer\GetCustomer
+{
+    /**
+     * @var AuthenticationInterface
+     */
+    protected $authentication;
+
+    /**
+     * @var CustomerRepositoryInterface
+     */
+    protected $customerRepository;
+
+    /**
+     * @var AccountManagementInterface
+     */
+    protected $accountManagement;
+
+    /**
+     * @param AuthenticationInterface $authentication
+     * @param CustomerRepositoryInterface $customerRepository
+     * @param AccountManagementInterface $accountManagement
+     */
+    public function __construct(
+        AuthenticationInterface $authentication,
+        CustomerRepositoryInterface $customerRepository,
+        AccountManagementInterface $accountManagement
+    ) {
+        $this->authentication = $authentication;
+        $this->customerRepository = $customerRepository;
+        $this->accountManagement = $accountManagement;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(ContextInterface $context): CustomerInterface
+    {
+        $currentUserId = $context->getUserId();
+        $currentUserType = $context->getUserType();
+
+        if (true === $this->isUserGuest($currentUserId, $currentUserType)) {
+            throw new GraphQlAuthorizationException(__('The current customer isn\'t authorized.'));
+        }
+
+        try {
+            $customer = $this->customerRepository->getById($currentUserId);
+        } catch (NoSuchEntityException $e) {
+            throw new GraphQlNoSuchEntityException(
+                __('Customer with id "%customer_id" does not exist.', ['customer_id' => $currentUserId]),
+                $e
+            );
+        } catch (LocalizedException $e) {
+            throw new GraphQlInputException(__($e->getMessage()));
+        }
+
+        if (true === $this->authentication->isLocked($currentUserId)) {
+            throw new GraphQlAuthenticationException(__('The account is locked.'));
+        }
+
+        try {
+            $confirmationStatus = $this->accountManagement->getConfirmationStatus($currentUserId);
+        } catch (LocalizedException $e) {
+            throw new GraphQlInputException(__($e->getMessage()));
+        }
+
+        return $customer;
+    }
+
+    /**
+     * Checking if current customer is guest
+     *
+     * @param int|null $customerId
+     * @param int|null $customerType
+     * @return bool
+     */
+    protected function isUserGuest(?int $customerId, ?int $customerType): bool
+    {
+        if (null === $customerId || null === $customerType) {
+            return true;
+        }
+        return 0 === (int)$customerId || (int)$customerType === UserContextInterface::USER_TYPE_GUEST;
+    }
+}

--- a/src/Model/Customer/GetCustomer.php
+++ b/src/Model/Customer/GetCustomer.php
@@ -34,17 +34,17 @@ class GetCustomer extends \Magento\CustomerGraphQl\Model\Customer\GetCustomer
     /**
      * @var AuthenticationInterface
      */
-    protected $authentication;
+    private $authentication;
 
     /**
      * @var CustomerRepositoryInterface
      */
-    protected $customerRepository;
+    private $customerRepository;
 
     /**
      * @var AccountManagementInterface
      */
-    protected $accountManagement;
+    private $accountManagement;
 
     /**
      * @param AuthenticationInterface $authentication

--- a/src/Model/Resolver/ConfirmEmail.php
+++ b/src/Model/Resolver/ConfirmEmail.php
@@ -22,9 +22,17 @@ use Magento\Customer\Model\Session;
 use Magento\Customer\Api\AccountManagementInterface;
 use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Integration\Api\CustomerTokenServiceInterface;
+use Magento\Framework\Encryption\EncryptorInterface as Encryptor;
+use Magento\Customer\Model\AuthenticationInterface;
+use Magento\Customer\Model\CustomerRegistry;
 
 class ConfirmEmail implements ResolverInterface {
     const STATUS_TOKEN_EXPIRED = 'token_expired';
+
+    /**
+     * @var AuthenticationInterface
+     */
+    private $authentication;
 
     /**
      * @var Session
@@ -47,23 +55,41 @@ class ConfirmEmail implements ResolverInterface {
     protected $customerTokenService;
 
     /**
+     * @var Encryptor
+     */
+    protected $encryptor;
+
+    /**
+     * @var CustomerRegistry
+     */
+    protected $customerRegistry;
+
+    /**
      * ConfirmEmail constructor.
+     * @param AuthenticationInterface $authentication
      * @param Session $customerSession
      * @param AccountManagementInterface $customerAccountManagement
      * @param CustomerRepositoryInterface $customerRepository
      * @param CustomerTokenServiceInterface $customerTokenService
-     * @param CustomerDataProvider $customerDataProvider
+     * @param Encryptor $encryptor
+     * @param CustomerRegistry $customerRegistry
      */
     public function __construct(
+        AuthenticationInterface $authentication,
         Session $customerSession,
         AccountManagementInterface $customerAccountManagement,
         CustomerRepositoryInterface $customerRepository,
-        CustomerTokenServiceInterface $customerTokenService
+        CustomerTokenServiceInterface $customerTokenService,
+        Encryptor $encryptor,
+        CustomerRegistry $customerRegistry
     ) {
+        $this->authentication = $authentication;
         $this->customerTokenService = $customerTokenService;
         $this->session = $customerSession;
         $this->customerAccountManagement = $customerAccountManagement;
-        $this->customerRepository = $customerRepository;
+        $this->customerRepository = $customerface;
+        $this->encryptor = $encryptor;
+        $this->customerRegistry = $customerRegistry;
     }
 
     /**
@@ -86,16 +112,23 @@ class ConfirmEmail implements ResolverInterface {
             $key = $args['key'];
             $password = $args['password'];
 
-            $customer = $this->customerAccountManagement->activate($customerEmail, $key);
-            $this->session->setCustomerDataAsLoggedIn($customer);
-            $token = $this->customerTokenService->createCustomerAccessToken($customerEmail, $password);
-            return [
-                'customer' => $this->customerRepository->getById((int)$customer->getId()),
-                'status' => AccountManagementInterface::ACCOUNT_CONFIRMED,
-                'token' => $token
-            ];
+            $id = $this->customerRepository->get($customerEmail)->getId();
+            $currentPasswordHash = $this->customerRegistry->retrieveSecureData($id)->getPasswordHash();
+
+            if ($this->encryptor->validateHash($password, $currentPasswordHash)) {
+                $customer = $this->customerAccountManagement->activate($customerEmail, $key);
+
+                $this->session->setCustomerDataAsLoggedIn($customer);
+                $token = $this->customerTokenService->createCustomerAccessToken($customerEmail, $password);
+                return [
+                    'status' => AccountManagementInterface::ACCOUNT_CONFIRMED,
+                    'token' => $token
+                ];
+            } else {
+                throw new GraphQlInputException(__('Password is incorrect'));
+            }
         } catch (StateException $e) {
-            return [ 'status' => self::STATUS_TOKEN_EXPIRED ];
+            return ['status' => self::STATUS_TOKEN_EXPIRED];
         } catch (\Exception $e) {
             throw new GraphQlInputException(__('There was an error confirming the account'), $e);
         }

--- a/src/Model/Resolver/ConfirmEmail.php
+++ b/src/Model/Resolver/ConfirmEmail.php
@@ -87,7 +87,7 @@ class ConfirmEmail implements ResolverInterface {
         $this->customerTokenService = $customerTokenService;
         $this->session = $customerSession;
         $this->customerAccountManagement = $customerAccountManagement;
-        $this->customerRepository = $customerface;
+        $this->customerRepository = $customerRepository;
         $this->encryptor = $encryptor;
         $this->customerRegistry = $customerRegistry;
     }

--- a/src/Model/Resolver/ConfirmEmail.php
+++ b/src/Model/Resolver/ConfirmEmail.php
@@ -78,19 +78,17 @@ class ConfirmEmail implements ResolverInterface {
     )
     {
         if ($this->session->isLoggedIn()) {
-            return [ 'status' => AccountManagementInterface::ACCOUNT_CONFIRMATION_NOT_REQUIRED ];
+            $this->session->logOut();
         }
 
         try {
-            $customerId = $args['id'];
+            $customerEmail = $args['email'];
             $key = $args['key'];
             $password = $args['password'];
 
-            $customerEmail = $this->customerRepository->getById($customerId)->getEmail();
             $customer = $this->customerAccountManagement->activate($customerEmail, $key);
             $this->session->setCustomerDataAsLoggedIn($customer);
-            $token = $this->customerTokenService->createCustomerAccessToken($customer->getEmail(), $password);
-
+            $token = $this->customerTokenService->createCustomerAccessToken($customerEmail, $password);
             return [
                 'customer' => $this->customerRepository->getById((int)$customer->getId()),
                 'status' => AccountManagementInterface::ACCOUNT_CONFIRMED,

--- a/src/Model/Resolver/GenerateCustomerToken.php
+++ b/src/Model/Resolver/GenerateCustomerToken.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/module-customer-graph-ql
+ * @link https://github.com/scandipwa/module-customer-graph-ql
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\CustomerGraphQl\Model\Resolver;
+
+use Magento\Framework\Exception\AuthenticationException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlAuthenticationException;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Integration\Api\CustomerTokenServiceInterface;
+use Magento\Framework\Event\ManagerInterface as EventManager;
+
+/**
+ * Customers Token resolver, used for GraphQL request processing.
+ */
+class GenerateCustomerToken implements ResolverInterface
+{
+    /**
+     * @var CustomerTokenServiceInterface
+     */
+    private $customerTokenService;
+
+    /**
+     * @var EventManager
+     */
+    private $eventManager;
+
+    /**
+     * @param CustomerTokenServiceInterface $customerTokenService
+     */
+    public function __construct(
+        CustomerTokenServiceInterface $customerTokenService,
+        EventManager $eventManager
+    ) {
+        $this->customerTokenService = $customerTokenService;
+        $this->eventManager = $eventManager;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (empty($args['email'])) {
+            throw new GraphQlInputException(__('Specify the "email" value.'));
+        }
+
+        if (empty($args['password'])) {
+            throw new GraphQlInputException(__('Specify the "password" value.'));
+        }
+
+        try {
+            $customerToken = $this->customerTokenService->createCustomerAccessToken($args['email'], $args['password']);
+        } catch (AuthenticationException $e) {
+            throw new GraphQlAuthenticationException(__($e->getMessage()), $e);
+        }
+
+        if (isset($args['guest_quote_id'])) {
+            $guestToken = $args['guest_quote_id'];
+
+            $this->eventManager->dispatch('generate_customer_token_after', [
+                'guest_quote_id' => $guestToken,
+                'customer_token' => $customerToken
+            ]);
+        }
+
+        return ['token' => $customerToken];
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0"?>
 <!--
 /**
- * ScandiPWA - Progressive Web App for Magento
+ * ScandiPWA_CustomerGraphQl
  *
- * Copyright © Scandiweb, Inc. All rights reserved.
- * See LICENSE for license details.
- *
- * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
- * @package scandipwa/module-customer-graph-ql
- * @link https://github.com/scandipwa/module-customer-graph-ql
+ * @category    Scandiweb
+ * @package     ScandiPWA_CustomerGraphQl
+ * @author      Kirils Scerba <info@scandiweb.com>
+ * @copyright   Copyright (c) 2019 Scandiweb, Ltd (https://scandiweb.com)
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/module-customer-graph-ql
+ * @link https://github.com/scandipwa/module-customer-graph-ql
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+        <preference for="Magento\CustomerGraphQl\Model\Customer\ExtractCustomerData"
+                    type="ScandiPWA\CustomerGraphQl\Model\Customer\ExtractCustomerData"/>
+        <preference for="Magento\CustomerGraphQl\Model\Customer\GetCustomer"
+                    type="ScandiPWA\CustomerGraphQl\Model\Customer\GetCustomer"/>
+</config>

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -16,4 +16,6 @@
                     type="ScandiPWA\CustomerGraphQl\Model\Customer\ExtractCustomerData"/>
         <preference for="Magento\CustomerGraphQl\Model\Customer\GetCustomer"
                     type="ScandiPWA\CustomerGraphQl\Model\Customer\GetCustomer"/>
+        <preference for="Magento\CustomerGraphQl\Model\Resolver\GenerateCustomerToken"
+                    type="ScandiPWA\CustomerGraphQl\Model\Resolver\GenerateCustomerToken"/>
 </config>

--- a/src/etc/email_templates.xml
+++ b/src/etc/email_templates.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/module-customer-graph-ql
+ * @link https://github.com/scandipwa/module-customer-graph-ql
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Email:etc/email_templates.xsd">
+    <template id="customer_create_account_email_confirmation_template" label="New Account Confirmation Key" file="account_new_confirmation.html" type="html" module="ScandiPWA_CustomerGraphQl" area="frontend"/>
+    <template id="customer_create_account_email_confirmed_template" label="New Account Confirmed" file="account_new_confirmed.html" type="html" module="ScandiPWA_CustomerGraphQl" area="frontend"/>
+</config>

--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -13,6 +13,7 @@
 
 type Mutation {
     confirmCustomerEmail(key: String!, email: String!, password: String!): CreateCustomerType @resolver(class: "\\ScandiPWA\\CustomerGraphQl\\Model\\Resolver\\ConfirmEmail") @doc(description:"Confirm customer account")
+    generateCustomerToken(email: String!, password: String!, guest_quote_id: String): CustomerToken @resolver(class: "\\ScandiPWA\\CustomerGraphQl\\Model\\Resolver\\GenerateCustomerToken") @doc(description:"Retrieve the customer token")
     resendConfirmationEmail(email: String!): CustomerActionConfirmationType @resolver(class: "\\ScandiPWA\\CustomerGraphQl\\Model\\Resolver\\ResendConfirmationEmail") @doc(description:"Resend customer confirmation")
     forgotPassword(email: String!): CustomerActionConfirmationType @resolver(class: "\\ScandiPWA\\CustomerGraphQl\\Model\\Resolver\\ForgotPassword") @doc(description:"Resend customer confirmation")
     resetPassword(password: String!, token: String!, password_confirmation: String!): ResetPasswordType @resolver(class: "\\ScandiPWA\\CustomerGraphQl\\Model\\Resolver\\ResetPassword") @doc(description:"Resend customer confirmation")

--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -12,7 +12,7 @@
 # See COPYING.txt for license details.
 
 type Mutation {
-    confirmCustomerEmail(key: String!, id: String!, password: String!): CreateCustomerType @resolver(class: "\\ScandiPWA\\CustomerGraphQl\\Model\\Resolver\\ConfirmEmail") @doc(description:"Confirm customer account")
+    confirmCustomerEmail(key: String!, email: String!, password: String!): CreateCustomerType @resolver(class: "\\ScandiPWA\\CustomerGraphQl\\Model\\Resolver\\ConfirmEmail") @doc(description:"Confirm customer account")
     resendConfirmationEmail(email: String!): CustomerActionConfirmationType @resolver(class: "\\ScandiPWA\\CustomerGraphQl\\Model\\Resolver\\ResendConfirmationEmail") @doc(description:"Resend customer confirmation")
     forgotPassword(email: String!): CustomerActionConfirmationType @resolver(class: "\\ScandiPWA\\CustomerGraphQl\\Model\\Resolver\\ForgotPassword") @doc(description:"Resend customer confirmation")
     resetPassword(password: String!, token: String!, password_confirmation: String!): ResetPasswordType @resolver(class: "\\ScandiPWA\\CustomerGraphQl\\Model\\Resolver\\ResetPassword") @doc(description:"Resend customer confirmation")
@@ -35,4 +35,8 @@ type CreateCustomerType {
 
 type AvailabilityResponseType {
     isAvailable: Boolean
+}
+
+type Customer @doc(description: "Customer defines the customer name and address and other details") {
+    confirmation_required: Boolean @doc(description: "Email confirmation is required")
 }

--- a/src/view/frontend/email/account_new_confirmation.html
+++ b/src/view/frontend/email/account_new_confirmation.html
@@ -1,0 +1,27 @@
+<!--@subject {{trans "Please confirm your %store_name account" store_name=$store.getFrontendName()}} @-->
+<!--@vars {
+"var this.getUrl($store, 'account/confirm', [_query:[key:$customer.confirmation,email:$customer.email]])":"Account Confirmation URL",
+"var this.getUrl($store, 'my-account/dashboard')":"Customer Account URL",
+"var customer.email":"Customer Email",
+"var customer.name":"Customer Name"
+} @-->
+
+{{template config_path="design/email/header_template"}}
+
+<p class="greeting">{{trans "%name," name=$customer.name}}</p>
+<p>{{trans "You must confirm your %customer_email email before you can sign in (link is only valid once):" customer_email=$customer.email}}</p>
+<table class="button" width="100%" border="0" cellspacing="0" cellpadding="0">
+    <tr>
+        <td>
+            <table class="inner-wrapper" border="0" cellspacing="0" cellpadding="0" align="center">
+                <tr>
+                    <td align="center">
+                        <a href="{{var this.getUrl($store, 'account/confirm', [_query:[key:$customer.confirmation,email:$customer.email],_nosid:1])}}" target="_blank">{{trans "Confirm Your Account"}}</a>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+
+{{template config_path="design/email/footer_template"}}

--- a/src/view/frontend/email/account_new_confirmation.html
+++ b/src/view/frontend/email/account_new_confirmation.html
@@ -1,3 +1,15 @@
+<!--
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/module-customer-graph-ql
+ * @link https://github.com/scandipwa/module-customer-graph-ql
+ */
+-->
 <!--@subject {{trans "Please confirm your %store_name account" store_name=$store.getFrontendName()}} @-->
 <!--@vars {
 "var this.getUrl($store, 'account/confirm', [_query:[key:$customer.confirmation,email:$customer.email]])":"Account Confirmation URL",

--- a/src/view/frontend/email/account_new_confirmed.html
+++ b/src/view/frontend/email/account_new_confirmed.html
@@ -1,0 +1,48 @@
+<!--
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/module-customer-graph-ql
+ * @link https://github.com/scandipwa/module-customer-graph-ql
+ */
+-->
+<!--@subject {{trans "Welcome to %store_name" store_name=$store.getFrontendName()}} @-->
+<!--@vars {
+"var $this.getUrl($store,'my-account/dashboard')":"Customer Account URL",
+"var customer.email":"Customer Email",
+"var customer.name":"Customer Name"
+} @-->
+{{template config_path="design/email/header_template"}}
+<p class="greeting">{{trans "%name," name=$customer.name}}</p>
+<p>{{trans "Thank you for confirming your %store_name account." store_name=$store.getFrontendName()}}</p>
+<p>
+    {{trans
+        'To sign in to our site, use these credentials during checkout or on the <a href="%customer_url">My Account</a> page:'
+
+        customer_url=$this.getUrl($store,'my-account/dashboard',[_nosid:1])
+    |raw}}
+</p>
+<ul>
+    <li><strong>{{trans "Email:"}}</strong> {{var customer.email}}</li>
+    <li><strong>{{trans "Password:"}}</strong> <em>{{trans "Password you set when creating account"}}</em></li>
+</ul>
+<p>
+    {{trans
+        'Forgot your account password? Click <a href="%reset_url">here</a> to reset it.'
+
+        reset_url="$this.getUrl($store,'account/createPassword/',[_query:[id:$customer.id,token:$customer.rp_token],_nosid:1])"
+    |raw}}
+</p>
+<p>{{trans "When you sign in to your account, you will be able to:"}}</p>
+<ul>
+    <li>{{trans "Proceed through checkout faster"}}</li>
+    <li>{{trans "Check the status of orders"}}</li>
+    <li>{{trans "View past orders"}}</li>
+    <li>{{trans "Store alternative addresses (for shipping to multiple family members and friends)"}}</li>
+</ul>
+
+{{template config_path="design/email/footer_template"}}


### PR DESCRIPTION
- Tested `ConfirmCustomerEmail` mutation
- Added `confirmation_required` field for Customer type
- Changed `ConfirmCustomerEmail` mutation to accept `email` instead of `userId`
- Fixed links for email templates
- Updated `readme`

Features:
Custom logo can be set for every email: 
- Inside M2 admin navigate to `Content > Configuration > (choose theme and press) Edit > Other Settings > Transactional Emails > logo upload`
- With no logo uploaded Magento leaves its own logo in email template header.