### PR TITLE
#3671 - fix saving region after changing address

### DIFF
--- a/src/Model/Customer/Address/UpdateCustomerAddress.php
+++ b/src/Model/Customer/Address/UpdateCustomerAddress.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/module-customer-graph-ql
+ * @link https://github.com/scandipwa/module-customer-graph-ql
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\CustomerGraphQl\Model\Customer\Address;
+
+use Magento\Customer\Api\AddressRepositoryInterface;
+use Magento\Customer\Api\Data\AddressInterface;
+use Magento\CustomerGraphQl\Model\Customer\Address\GetAllowedAddressAttributes;
+use Magento\CustomerGraphQl\Model\Customer\Address\PopulateCustomerAddressFromInput;
+use Magento\CustomerGraphQl\Model\Customer\Address\UpdateCustomerAddress as SourceAddress;
+use Magento\Directory\Helper\Data as DirectoryData;
+use Magento\Directory\Model\ResourceModel\Region\CollectionFactory as RegionCollectionFactory;
+use Magento\Framework\Api\DataObjectHelper;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+
+/**
+ * @inheridoc
+ */
+class UpdateCustomerAddress extends SourceAddress
+{
+    /**
+     * @var AddressRepositoryInterface
+     */
+    protected $addressRepository;
+
+    /**
+     * @var DataObjectHelper
+     */
+    protected $dataObjectHelper;
+
+    /**
+     * @var array
+     */
+    protected $restrictedKeys;
+
+    /**
+     * @var ValidateAddress
+     */
+    protected $addressValidator;
+
+    /**
+     * @var PopulateCustomerAddressFromInput
+     */
+    protected $populateCustomerAddressFromInput;
+
+    /**
+     * @param GetAllowedAddressAttributes $getAllowedAddressAttributes
+     * @param AddressRepositoryInterface $addressRepository
+     * @param DataObjectHelper $dataObjectHelper
+     * @param DirectoryData $directoryData
+     * @param RegionCollectionFactory $regionCollectionFactory
+     * @param ValidateAddress $addressValidator
+     * @param PopulateCustomerAddressFromInput $populateCustomerAddressFromInput
+     * @param array $restrictedKeys
+     */
+    public function __construct(
+        GetAllowedAddressAttributes $getAllowedAddressAttributes,
+        AddressRepositoryInterface $addressRepository,
+        DataObjectHelper $dataObjectHelper,
+        DirectoryData $directoryData,
+        RegionCollectionFactory $regionCollectionFactory,
+        ValidateAddress $addressValidator,
+        PopulateCustomerAddressFromInput $populateCustomerAddressFromInput,
+        array $restrictedKeys = []
+    ) {
+        parent::__construct(
+            $getAllowedAddressAttributes,
+            $addressRepository,
+            $dataObjectHelper,
+            $directoryData,
+            $regionCollectionFactory,
+            $addressValidator,
+            $populateCustomerAddressFromInput,
+            $restrictedKeys
+        );
+
+        $this->addressRepository = $addressRepository;
+        $this->dataObjectHelper = $dataObjectHelper;
+        $this->addressValidator = $addressValidator;
+        $this->populateCustomerAddressFromInput = $populateCustomerAddressFromInput;
+        $this->restrictedKeys = $restrictedKeys;
+    }
+
+    /**
+     * @inheridoc
+     */
+    public function execute(AddressInterface $address, array $data): void
+    {
+        if (isset($data['country_code'])) {
+            $data['country_id'] = $data['country_code'];
+        }
+        $this->validateData($data);
+
+        $filteredData = array_diff_key($data, array_flip($this->restrictedKeys));
+        $this->dataObjectHelper->populateWithArray($address, $filteredData, AddressInterface::class);
+
+        if (!empty($data['region']['region_id'])) {
+            $address->setRegionId($address->getRegion()->getRegionId());
+        } else {
+            $data['region']['region_id'] = null;
+
+            # If new address doesn't have selectable region, make sure that old region id is removed from DB
+            $address->setRegionId(null);
+        }
+
+        $this->populateCustomerAddressFromInput->execute($address, $filteredData);
+        $this->addressValidator->execute($address);
+
+        try {
+            $this->addressRepository->save($address);
+        } catch (LocalizedException $e) {
+            throw new GraphQlInputException(__($e->getMessage()), $e);
+        }
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -16,6 +16,8 @@
                 type="ScandiPWA\CustomerGraphQl\Model\Customer\GetCustomer"/>
     <preference for="Magento\CustomerGraphQl\Model\Customer\Address\ValidateAddress"
                 type="ScandiPWA\CustomerGraphQl\Model\Customer\Address\ValidateAddress"/>
+    <preference for="Magento\CustomerGraphQl\Model\Customer\Address\UpdateCustomerAddress"
+                type="ScandiPWA\CustomerGraphQl\Model\Customer\Address\UpdateCustomerAddress"/>
     <preference for="Magento\CustomerGraphQl\Model\Customer\CheckCustomerPassword"
                 type="ScandiPWA\CustomerGraphQl\Model\Customer\CheckCustomerPassword"/>
     <preference for="Magento\CustomerGraphQl\Model\Context\AddUserInfoToContext"


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3671

**Problem:**
* When customer changes address from country, which supports regions, to country, which doesn't support them, saving changed region data doesn't work correctly.

**In this PR:**
* Setting region id to null, if new country doesn't support selecting region from the list.
