### PR TITLE
[3780] Redirect for newsletter confirmation

### DIFF
--- a/src/Controller/Subscriber/Confirm.php
+++ b/src/Controller/Subscriber/Confirm.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ScandiPWA\CustomerGraphQl\Controller\Subscriber;
+
+class Confirm extends \Magento\Newsletter\Controller\Subscriber\Confirm
+{
+    /**
+     * Subscription confirm action.
+     *
+     * @return \Magento\Framework\Controller\Result\Redirect
+     */
+    public function execute()
+    {
+        $id = (int)$this->getRequest()->getParam('id');
+        $code = (string)$this->getRequest()->getParam('code');
+
+        if ($id && $code) {
+            /** @var \Magento\Newsletter\Model\Subscriber $subscriber */
+            $subscriber = $this->_subscriberFactory->create()->load($id);
+
+            if ($subscriber->getId() && $subscriber->getCode()) {
+                if ($subscriber->confirm($code)) {
+                    $this->messageManager->addSuccessMessage(__('Your subscription has been confirmed.'));
+                } else {
+                    $this->messageManager->addErrorMessage(__('This is an invalid subscription confirmation code.'));
+                }
+            } else {
+                $this->messageManager->addErrorMessage(__('This is an invalid subscription ID.'));
+            }
+        }
+        /** @var \Magento\Framework\Controller\Result\Redirect $redirect */
+        $redirect = $this->resultFactory->create(\Magento\Framework\Controller\ResultFactory::TYPE_REDIRECT);
+        $redirectUrl = $this->_storeManager->getStore()->getBaseUrl().'newsletter/confirm/id/'.$id.'/code/'.$code;
+        return $redirect->setUrl($redirectUrl);
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -22,6 +22,8 @@
                 type="ScandiPWA\CustomerGraphQl\Model\Customer\CheckCustomerPassword"/>
     <preference for="Magento\CustomerGraphQl\Model\Context\AddUserInfoToContext"
                 type="ScandiPWA\CustomerGraphQl\Model\Context\AddUserInfoToContext"/>
+    <preference for="Magento\Newsletter\Controller\Subscriber\Confirm"
+                type="ScandiPWA\CustomerGraphQl\Controller\Subscriber\Confirm"/>
 	<type name="Magento\Catalog\Helper\Data">
         <arguments>
             <argument name="customerSession" xsi:type="object">ScandiPWA\CustomerGraphQl\Model\Session</argument>

--- a/src/etc/module.xml
+++ b/src/etc/module.xml
@@ -19,6 +19,7 @@
             <module name="Magento_Integration"/>
             <module name="Magento_Customer"/>
             <module name="Magento_CustomerGraphQl"/>
+            <module name="Magento_Newsletter"/>
         </sequence>
 	</module>
 </config>


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3780

**Problem:**
* After clicking the link in confirmation email user gets redirected to default home page

**In this PR:**
* Preferenced Confirm class from module Magento_Newsletter to redirect to a confirm page
