### PR TITLE
[4515] Correct customer id for context

### DIFF
--- a/src/Model/Context/AddUserInfoToContext.php
+++ b/src/Model/Context/AddUserInfoToContext.php
@@ -35,42 +35,42 @@ class AddUserInfoToContext extends CoreAddUserInfoToContext
     /**
      * @var UserContextInterface
      */
-    protected $userContext;
+    protected UserContextInterface $userContext;
 
     /**
      * @var Session
      */
-    protected $session;
+    protected Session $session;
 
     /**
      * @var CustomerRepository
      */
-    protected $customerRepository;
+    protected CustomerRepository $customerRepository;
 
     /**
      * @var CustomerTokenServiceInterface
      */
-    protected $customerTokenService;
+    protected CustomerTokenServiceInterface $customerTokenService;
 
     /**
      * @var TokenCollectionFactory
      */
-    protected $tokenModelCollectionFactory;
+    protected TokenCollectionFactory $tokenModelCollectionFactory;
 
     /**
      * @var DateTime
      */
-    protected $dateTime;
+    protected DateTime $dateTime;
 
     /**
      * @var Request
      */
-    protected $request;
+    protected Request $request;
 
     /**
      * @var TokenFactory
      */
-    protected $tokenFactory;
+    protected TokenFactory $tokenFactory;
 
     /**
      * @param UserContextInterface $userContext
@@ -114,11 +114,6 @@ class AddUserInfoToContext extends CoreAddUserInfoToContext
     public function execute(ContextParametersInterface $contextParameters): ContextParametersInterface
     {
         $currentUserId = $this->getCurrentUserId();
-
-        if ($currentUserId !== null) {
-            $currentUserId = (int)$currentUserId;
-        }
-
         $contextParameters->setUserId($currentUserId);
 
         $currentUserType = $this->userContext->getUserType();
@@ -153,21 +148,24 @@ class AddUserInfoToContext extends CoreAddUserInfoToContext
     /**
      * Returns authorized customer id; if valid token passed in header.
      *
-     * @return int|null
+     * @return int
      */
-    protected function getCurrentUserId()
+    public function getCurrentUserId(): int
     {
         $authorizationHeaderValue = $this->request->getHeader(self::AUTH_HEADER);
+
         if (!$authorizationHeaderValue) {
             return 0;
         }
 
         $headerPieces = explode(' ', $authorizationHeaderValue);
+
         if (count($headerPieces) !== 2) {
             return 0;
         }
 
         $tokenType = strtolower($headerPieces[0]);
+
         if ($tokenType !== self::AUTH_HEADER_TYPE) {
             return 0;
         }
@@ -179,7 +177,7 @@ class AddUserInfoToContext extends CoreAddUserInfoToContext
             return 0;
         }
 
-        return $this->userContext->getUserId();
+        return (int)$this->userContext->getUserId();
     }
 
     /**

--- a/src/Model/Resolver/RevokeCustomerToken.php
+++ b/src/Model/Resolver/RevokeCustomerToken.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/module-customer-graph-ql
+ * @link https://github.com/scandipwa/module-customer-graph-ql
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\CustomerGraphQl\Model\Resolver;
+
+use Magento\CustomerGraphQl\Model\Resolver\RevokeCustomerToken as SourceRevokeCustomerToken;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Customer\Model\Session;
+use Magento\Integration\Api\CustomerTokenServiceInterface;
+
+/**
+ * @inheritdoc
+ */
+class RevokeCustomerToken extends SourceRevokeCustomerToken
+{
+    /**
+     * @var Session
+     */
+    protected $session;
+
+    /**
+     * @param CustomerTokenServiceInterface $customerTokenService
+     * @param Session $session
+     */
+    public function __construct(
+        CustomerTokenServiceInterface $customerTokenService,
+        Session $session
+    ) {
+        parent::__construct($customerTokenService);
+
+        $this->session = $session;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field, $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        $output = parent::resolve($field, $context, $info, $value, $args);
+        $this->session->logout();
+
+        return $output;
+    }
+}

--- a/src/Model/Resolver/RevokeCustomerToken.php
+++ b/src/Model/Resolver/RevokeCustomerToken.php
@@ -27,7 +27,7 @@ class RevokeCustomerToken extends SourceRevokeCustomerToken
     /**
      * @var Session
      */
-    protected $session;
+    protected Session $session;
 
     /**
      * @param CustomerTokenServiceInterface $customerTokenService

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -25,7 +25,9 @@
     <preference for="Magento\Integration\Model\CustomerTokenService"
                 type="ScandiPWA\CustomerGraphQl\Model\CustomerTokenService"/>
     <preference for="Magento\CustomerGraphQl\Model\Customer\UpdateCustomerAccount"
-                type="ScandiPWA\CustomerGraphQl\Model\Customer\UpdateCustomerAccount"/>            
+                type="ScandiPWA\CustomerGraphQl\Model\Customer\UpdateCustomerAccount"/>   
+    <preference for="Magento\CustomerGraphQl\Model\Resolver\RevokeCustomerToken"
+                type="ScandiPWA\CustomerGraphQl\Model\Resolver\RevokeCustomerToken"/>         
     <type name="Magento\Catalog\Helper\Data">
         <arguments>
             <argument name="customerSession" xsi:type="object">ScandiPWA\CustomerGraphQl\Model\Session</argument>


### PR DESCRIPTION
**Original issue:** 
* Fixes https://github.com/scandipwa/scandipwa/issues/4515

**Problem:** 
* Context for customer returns incorrect customer_id, due to context for session storing customer data after token revoking (after logout).

**In this PR:** 
* Passing authorized customer id if valid token passed in header.
* Revoking session.