### PR TITLE
#3243 - Reset confirmation when reset password

### DIFF
--- a/src/Model/Resolver/ResetPassword.php
+++ b/src/Model/Resolver/ResetPassword.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ScandiPWA\CustomerGraphQl\Model\Resolver;
 
 use Magento\Customer\Api\CustomerRepositoryInterface;
-use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
@@ -66,8 +65,7 @@ class ResetPassword implements ResolverInterface {
         $this->session = $customerSession;
         $this->accountManagement = $accountManagement;
         $this->customerRepository = $customerRepository;
-        $this->confirmByToken = $confirmByToken
-            ?? ObjectManager::getInstance()->get(ConfirmCustomerByToken::class);
+        $this->confirmByToken = $confirmByToken;
     }
 
     /**

--- a/src/Model/Resolver/ResetPassword.php
+++ b/src/Model/Resolver/ResetPassword.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ScandiPWA\CustomerGraphQl\Model\Resolver;
 
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
@@ -20,6 +21,7 @@ use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\Customer\Model\Session;
 use Magento\Customer\Api\AccountManagementInterface;
+use Magento\Customer\Model\ForgotPasswordToken\ConfirmCustomerByToken;
 
 class ResetPassword implements ResolverInterface {
     const STATUS_PASSWORDS_MISS_MATCH = 'passwords_miss_match';
@@ -36,12 +38,25 @@ class ResetPassword implements ResolverInterface {
      */
     protected $session;
 
+    /**
+     * @var ConfirmCustomerByToken
+     */
+    protected ConfirmCustomerByToken $confirmByToken;
+
+    /**
+     * @param Session $customerSession
+     * @param AccountManagementInterface $accountManagement
+     * @param ConfirmCustomerByToken|null $confirmByToken
+     */
     public function __construct(
         Session $customerSession,
-        AccountManagementInterface $accountManagement
+        AccountManagementInterface $accountManagement,
+        ConfirmCustomerByToken $confirmByToken = null
     ) {
         $this->session = $customerSession;
         $this->accountManagement = $accountManagement;
+        $this->confirmByToken = $confirmByToken
+            ?? ObjectManager::getInstance()->get(ConfirmCustomerByToken::class);
     }
 
     /**
@@ -73,8 +88,13 @@ class ResetPassword implements ResolverInterface {
         }
 
         try {
+            // Check if the user has not yet confirmed the account
+            // and if not do this along with changing the password
+            $this->confirmByToken->execute($resetPasswordToken);
+
             $this->accountManagement->resetPassword(null, $resetPasswordToken, $password);
             $this->session->unsRpToken();
+
             return [ 'status' => self::STATUS_PASSWORD_UPDATED ];
         } catch (InputException $e) {
             throw new GraphQlInputException(__($e->getMessage()));


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3243

**Problem:**
* If the user has not yet confirmed the account, but has reset the password, verification is still required, which is inconsistent with behavior in Luma

**In this PR:**
* Changing the password also resets the need to confirmed customer account
