### PR TITLE
added customer_id field and get customers email and passing to the resetPassword method

### DIFF
--- a/src/Model/Resolver/ResetPassword.php
+++ b/src/Model/Resolver/ResetPassword.php
@@ -40,7 +40,7 @@ class ResetPassword implements ResolverInterface {
     /**
      * @var CustomerRepositoryInterface
      */
-    private $customerRepository;
+    protected $customerRepository;
 
     /**
      * ResetPassword constructor.
@@ -72,7 +72,11 @@ class ResetPassword implements ResolverInterface {
         $passwordConfirmation = $args['password_confirmation'];
         $customerId = $args['customer_id'];
 
-        $customerEmail = $this->customerRepository->getById($customerId)->getEmail();
+        try {
+            $customerEmail = $this->customerRepository->getById($customerId)->getEmail();
+        } catch (\Exception $exception) {
+            throw new GraphQlInputException(__('No customer found'));
+        }
 
         if ($password !== $passwordConfirmation) {
             return [
@@ -95,7 +99,7 @@ class ResetPassword implements ResolverInterface {
         } catch (InputException $e) {
             throw new GraphQlInputException(__($e->getMessage()));
         } catch (\Exception $exception) {
-            throw new GraphQlInputException(__('Something went wrong while saving the new password.'));
+            throw new GraphQlInputException(__('Your password reset link has expired.'));
         }
     }
 }

--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -15,7 +15,7 @@ type Mutation {
     confirmCustomerEmail(key: String!, email: String!, password: String!): CreateCustomerType @resolver(class: "\\ScandiPWA\\CustomerGraphQl\\Model\\Resolver\\ConfirmEmail") @doc(description:"Confirm customer account")
     resendConfirmationEmail(email: String!): CustomerActionConfirmationType @resolver(class: "\\ScandiPWA\\CustomerGraphQl\\Model\\Resolver\\ResendConfirmationEmail") @doc(description:"Resend customer confirmation")
     forgotPassword(email: String!): CustomerActionConfirmationType @resolver(class: "\\ScandiPWA\\CustomerGraphQl\\Model\\Resolver\\ForgotPassword") @doc(description:"Resend customer confirmation")
-    s_resetPassword(password: String!, token: String!, password_confirmation: String!): ResetPasswordType @resolver(class: "\\ScandiPWA\\CustomerGraphQl\\Model\\Resolver\\ResetPassword") @doc(description:"Resend customer confirmation")
+    s_resetPassword(customer_id: String!,password: String!, token: String!, password_confirmation: String!): ResetPasswordType @resolver(class: "\\ScandiPWA\\CustomerGraphQl\\Model\\Resolver\\ResetPassword") @doc(description:"Resend customer confirmation")
 }
 
 type CustomerActionConfirmationType {


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa#4122 

**Problem:**
* In Magento 2.4.4 there is strict checking for an email while resetting a customer password via email

**In this PR:**
* The email provides a customer with a link that leads to a resetting page and it contains `customer_id ` as one of the params, so in order to get the customer's email, I pass this id to BE and get the email from that id, and further pass the email to the reset method. Before this PR `null` was sent instead of email.
*scandipwa/scandipwa#4841
