### PR TITLE
#2685 - Check if order email and customer email the same

### DIFF
--- a/src/Model/Resolver/CreateCustomer.php
+++ b/src/Model/Resolver/CreateCustomer.php
@@ -89,11 +89,14 @@ class CreateCustomer extends SourceCreateCustomer
 
         if (isset($args['input']['orderID']) && !empty($args['input']['orderID']) && isset($output['customer']['id'])) {
             $orderModel = $this->orderFactory->create()->loadByIncrementId($args['input']['orderID']);
+            $orderCustomerEmail = $orderModel->getCustomerEmail();
 
-            $orderModel->setCustomerId($output['customer']['id']);
-            $orderModel->setCustomerIsGuest(0);
+            if ($args['input']['email'] === $orderCustomerEmail) {
+                $orderModel->setCustomerId($output['customer']['id']);
+                $orderModel->setCustomerIsGuest(0);
 
-            $orderModel->save();
+                $orderModel->save();
+            }
         }
 
         return $output;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/2685
* Should be included in https://github.com/scandipwa/scandipwa/pull/4843

**Problem:**
* Associates the user with the order, even if the order was made with a different email

**In this PR:**
* Associates a user with an order only if the order is completed with the same email