### PR TITLE
#3243 - Change reset confirmation function

### DIFF
--- a/src/Model/Resolver/ResetPassword.php
+++ b/src/Model/Resolver/ResetPassword.php
@@ -116,7 +116,7 @@ class ResetPassword implements ResolverInterface {
         try {
             // Check if the user has not yet confirmed the account
             // and if not do this along with changing the password
-            $this->confirmByToken->execute($resetPasswordToken);
+            $this->confirmByToken->resetCustomerConfirmation((int)$customerId);
 
             $this->accountManagement->resetPassword($customerEmail, $resetPasswordToken, $password);
             $this->authentication->unlock($customerId);


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3243

**Problem:**
* confirmByToken not working for customer

**In this PR:**
* Used another function to reset confirmation, according to magneto 2.4.4
