### PR TITLE
#1623 - Validate reset password token

### DIFF
--- a/src/Model/Resolver/ResetPassword.php
+++ b/src/Model/Resolver/ResetPassword.php
@@ -87,6 +87,12 @@ class ResetPassword implements ResolverInterface {
             throw new GraphQlInputException(__('No customer found'));
         }
 
+        try {
+            $this->accountManagement->validateResetPasswordLinkToken((int)$customerId, $resetPasswordToken);
+        } catch (\Exception $exception) {
+            throw new GraphQlInputException(__($exception->getMessage()));
+        }
+
         if ($password !== $passwordConfirmation) {
             return [
                 'token' => $resetPasswordToken,


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/1623

**Problem:**
* Error message 'Error! Something went wrong' appears if user taps 'Update password' if the token is expired

**In this PR:**
* Validate the token before attempting to change the password